### PR TITLE
Fix rule to use boot context

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -361,8 +361,8 @@ promote:
 	$(dune) promote $(ws_main)
 
 .PHONY: fmt
-fmt: duneconf/main.ws
-	$(dune) build $(ws_main) @fmt --auto-promote
+fmt: duneconf/boot.ws ocaml/dirs-to-ignore.inc
+	$(dune) build $(ws_boot) @fmt --auto-promote
 
 .PHONY: check-fmt
 check-fmt:


### PR DESCRIPTION
For formatting purposes we are always using the formatting binary from opam.

Therefore it doesn't matter which context is used because we never use the compiler or stdlib while formatting.